### PR TITLE
Release/2.0.5

### DIFF
--- a/src/Rubicon.PdfService.Contract/Properties/AssemblyInfo.cs
+++ b/src/Rubicon.PdfService.Contract/Properties/AssemblyInfo.cs
@@ -47,5 +47,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion ("2.0.4.0")]
-[assembly: AssemblyFileVersion ("2.0.4.0")]
+[assembly: AssemblyVersion ("2.0.5.0")]
+[assembly: AssemblyFileVersion ("2.0.5.0")]

--- a/src/Rubicon.PdfService.Contract/Rubicon.PdfService.Contract.csproj
+++ b/src/Rubicon.PdfService.Contract/Rubicon.PdfService.Contract.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Result.cs" />
     <Compile Include="SourceDocument.cs" />
+    <Compile Include="SourceDocumentInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Rubicon.Pdf.Service.Contract.licenseheader" />

--- a/src/Rubicon.PdfService.Contract/SourceDocumentInfo.cs
+++ b/src/Rubicon.PdfService.Contract/SourceDocumentInfo.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Serialization;
+
+namespace Rubicon.PdfService.Contract;
+
+[XmlRoot]
+public class SourceDocumentInfo
+{
+  public string FilePath;
+  public string Title;
+  public SourceDocument.OutlineHierarchyMode HierarchyMode;
+  public bool StartOnOddPage;
+  
+  [XmlIgnore] 
+  public IDictionary<string, object> BookmarkStyles;
+
+  [XmlArray("BookmarkStyles")]
+  public SerializableKeyValuePair<string, object>[] BookmarkStylesSerializationHelper
+  {
+    get => BookmarkStyles?.Select(p => p.ToSerializablePair()).ToArray();
+    set => BookmarkStyles = value?.ToDictionary(p => p.Key, p => p.Value);
+  }
+}

--- a/src/Rubicon.PdfService/Properties/AssemblyInfo.cs
+++ b/src/Rubicon.PdfService/Properties/AssemblyInfo.cs
@@ -47,8 +47,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion ("2.0.4.0")]
-[assembly: AssemblyFileVersion ("2.0.4.0")]
+[assembly: AssemblyVersion ("2.0.5.0")]
+[assembly: AssemblyFileVersion ("2.0.5.0")]
 
 namespace Rubicon.PdfService
 {

--- a/src/Rubicon.PdfService/Rubicon.PdfService.csproj
+++ b/src/Rubicon.PdfService/Rubicon.PdfService.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32bit>false</Prefer32bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32bit>false</Prefer32bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BouncyCastle.Cryptography">


### PR DESCRIPTION
Fixed "Merge" mode memory issues:
* Merge now expects serialized SourceDocumentInfo (instead of SourceDocument) as input files
* Contents are now read from PDF files instead of being deserialized from XML elements
* Contents are now read on demand during merge and the allocated memory is freed after concatenation
* Bookmarks are now added during merge instead of post-merge (if HierarchyMode != None)
* Added optional --partialreadthreshold option to "Merge" mode (can be used for merging very large files)

Rubicon.PdfService.exe: Set Prefer32bit to false

Updated version to 2.0.5.0